### PR TITLE
Improve text clarity and structure in differential geometry post

### DIFF
--- a/content/posts/geometry-of-differential.md
+++ b/content/posts/geometry-of-differential.md
@@ -16,7 +16,57 @@ Differentiation is often taught as a collection of rules and formulas. But at it
 
 This post builds these concepts from first principles, emphasizing geometric intuition and the linear algebra structure that unifies them.
 
-## Part 1: The Differential as Linear Approximation
+## Points and Directions: The Foundation of Tangent Space
+
+Before diving into the differential, we need to establish a fundamental conceptual distinction that underlies all of differential geometry: **the difference between a point and a direction**.
+
+Consider standing at a specific location on a hillside. Your position is a **point**—a location in space described by coordinates. But now imagine you want to walk somewhere. To describe your motion, specifying your current position isn't enough. You need to specify **which way you're going**—a direction.
+
+This distinction seems obvious in everyday life, but it's profound mathematically. A point answers "where am I?" while a direction answers "which way am I moving?" These are fundamentally different types of geometric objects, and confusing them leads to misunderstanding differentiation.
+
+### Points Live in the Manifold
+
+When we write $f: \mathbb{R}^n \to \mathbb{R}^m$, the domain $\mathbb{R}^n$ is a collection of points. Each point $\mathbf{a} \in \mathbb{R}^n$ is a location, described by $n$ coordinates. For a function $f: \mathbb{R}^2 \to \mathbb{R}$ describing a hillside, a point $(x_0, y_0)$ tells us where we're standing on the ground.
+
+But here's what points cannot do: **you cannot add two points in a meaningful way**. If you're at location $(3, 5)$ and your friend is at location $(2, 7)$, what does $(3,5) + (2,7) = (5, 12)$ mean? It's not another meaningful location—it's a formal manipulation without geometric meaning. Points don't form a vector space; they form what we call a **manifold** or simply "space."
+
+### Directions Live in the Tangent Space
+
+A direction is completely different. A direction doesn't tell you where you are—it tells you how to change position. When you move from point $\mathbf{a}$ to nearby point $\mathbf{a} + \mathbf{h}$, the vector $\mathbf{h}$ represents a **displacement** or **direction of motion**.
+
+Directions *do* form a vector space. You can add two directions to get a combined direction. You can scale a direction to make it faster or slower. If "north" and "east" are directions, then "north + east" gives "northeast"—a perfectly sensible combined direction.
+
+Crucially, **directions are attached to points**. The direction "north" at your current location and "north" at a different location might point toward different destinations in space. The collection of all possible directions from a specific point $\mathbf{a}$ forms a vector space called the **tangent space** at $\mathbf{a}$, denoted $T_{\mathbf{a}}\mathbb{R}^n$.
+
+For Euclidean space $\mathbb{R}^n$, the tangent space at every point is isomorphic to $\mathbb{R}^n$ itself—every point has $n$ independent directions you can move. But conceptually, they're different: one is positions, the other is velocities.
+
+### The Differential Maps Between Tangent Spaces
+
+Now we can understand what the differential really does. When $f: \mathbb{R}^n \to \mathbb{R}^m$ maps points to points, the differential $Df(\mathbf{a})$ maps **directions to directions**:
+
+$$
+Df(\mathbf{a}): T_{\mathbf{a}}\mathbb{R}^n \to T_{f(\mathbf{a})}\mathbb{R}^m
+$$
+
+If you're moving in direction $\mathbf{h}$ at point $\mathbf{a}$ in the input space, the differential tells you: "in the output space, at point $f(\mathbf{a})$, you'll be moving in direction $Df(\mathbf{a})(\mathbf{h})$."
+
+This is why the differential is a **linear map**. Directions form vector spaces, and the differential is a linear transformation between these vector spaces. If you double your speed in the input direction, your speed in the output direction doubles. If you combine two input directions, the output direction is the combination of the corresponding output directions.
+
+Think of $f$ as a landscape transformation—perhaps stretching, rotating, or warping space. A point $\mathbf{a}$ maps to point $f(\mathbf{a})$. But if you're walking in direction $\mathbf{h}$ at point $\mathbf{a}$, after the transformation you'll be walking in direction $Df(\mathbf{a})(\mathbf{h})$ at point $f(\mathbf{a})$. The differential tracks how directions transform, not where points go—that's what $f$ itself does.
+
+### Why This Matters for Understanding Differentiation
+
+This point-versus-direction perspective clarifies several confusing aspects of calculus:
+
+**Why is the derivative a linear approximation?** Because we're approximating how the function transforms directions near a point. Linear maps are the simplest transformations of directions.
+
+**Why does the chain rule multiply Jacobians?** Because composing functions means composing how they transform directions. If $f$ transforms input directions by $Df(\mathbf{a})$ and $g$ transforms its input directions by $Dg(f(\mathbf{a}))$, then the composition transforms directions by the composition of these linear maps—that's matrix multiplication.
+
+**What is the gradient, really?** For scalar functions $f: \mathbb{R}^n \to \mathbb{R}$, the differential maps $n$-dimensional directions to $1$-dimensional directions (just numbers). The gradient is the unique vector such that this mapping equals the inner product with that vector. It lives in the tangent space and points in the direction of steepest ascent.
+
+With this foundation—understanding points as positions and directions as elements of tangent spaces—we can now properly define the differential and see why it takes the form it does.
+
+## The Differential as Linear Approximation
 
 ### What Problem Does Differentiation Solve?
 
@@ -24,11 +74,7 @@ Suppose we have a function $f: \mathbb{R}^n \to \mathbb{R}^m$ that we want to un
 
 **The fundamental idea of differentiation:** Replace $f$ with a simpler function that approximates it well near $\mathbf{a}$.
 
-What's the simplest kind of function? A linear function. Linear functions:
-- Are completely characterized by a matrix
-- Are easy to compute with
-- Are easy to compose
-- Have well-understood geometric properties
+What's the simplest kind of function? A linear function. Linear functions are completely characterized by matrices, making them easy to compute with and compose. They have well-understood geometric properties that make analysis tractable.
 
 So we ask: **Can we approximate $f$ near $\mathbf{a}$ with a linear function?**
 
@@ -42,10 +88,7 @@ $$
 
 where $o(\|\mathbf{h}\|)$ means "terms that go to zero faster than $\|\mathbf{h}\|$" as $\mathbf{h} \to \mathbf{0}$.
 
-**What this means geometrically:**
-- We can approximate the change in $f$ by a linear function $L$
-- The approximation error becomes negligible compared to the size of the perturbation $\mathbf{h}$
-- Near $\mathbf{a}$, the function $f$ "looks like" the linear function $L$ (plus a constant)
+**What this means geometrically:** We can approximate the change in $f$ by a linear function $L$, and the approximation error becomes negligible compared to the size of the perturbation $\mathbf{h}$. Near $\mathbf{a}$, the function $f$ "looks like" the linear function $L$ (plus a constant).
 
 The linear map $L$ is called the **differential** of $f$ at $\mathbf{a}$, denoted $Df(\mathbf{a})$ or $df_{\mathbf{a}}$.
 
@@ -105,15 +148,9 @@ Near $\mathbf{a}$, the graph of $f$ is well-approximated by this tangent hyperpl
 
 ### Why This Perspective Matters
 
-Understanding the differential as a linear map (rather than just "the derivative") is essential for:
+Understanding the differential as a linear map (rather than just "the derivative") is essential for composition through the chain rule, where differentials compose exactly like linear maps do. The implicit function theorem becomes a statement about inverting differentials. In optimization, critical points are precisely where the differential is zero. Newton's method leverages the differential to linearize equations for numerical solving. And in differential geometry, tangent spaces are fundamentally defined via differentials.
 
-1. **Composition (Chain Rule):** Differentials compose like linear maps
-2. **Implicit Functions:** The implicit function theorem is about inverting differentials
-3. **Optimization:** Critical points are where the differential is zero
-4. **Numerical Methods:** Newton's method uses the differential to linearize equations
-5. **Differential Geometry:** Tangent spaces are defined via differentials
-
-## Part 2: The Gradient—Scalar Functions and Inner Products
+## The Gradient—Scalar Functions and Inner Products
 
 Let's specialize to the most common case: **scalar-valued functions** $f: \mathbb{R}^n \to \mathbb{R}$.
 
@@ -184,10 +221,7 @@ $$
 
 Equality holds when $\mathbf{v}$ points in the same direction as $\nabla f(\mathbf{a})$.
 
-**Conclusion:**
-- The gradient $\nabla f(\mathbf{a})$ points in the direction of steepest ascent
-- Its magnitude $\|\nabla f(\mathbf{a})\|$ is the rate of increase in that direction
-- The negative gradient $-\nabla f(\mathbf{a})$ points in the direction of steepest descent
+**Conclusion:** The gradient $\nabla f(\mathbf{a})$ points in the direction of steepest ascent, with its magnitude $\|\nabla f(\mathbf{a})\|$ giving the rate of increase in that direction. Conversely, the negative gradient $-\nabla f(\mathbf{a})$ points in the direction of steepest descent.
 
 This geometric insight is the foundation of gradient descent optimization.
 
@@ -221,10 +255,7 @@ $$
 
 Since $\mathbf{c}'(0)$ is tangent to the level set, and this holds for any such curve, $\nabla f(\mathbf{a})$ is orthogonal to the tangent space of the level set.
 
-**Geometric picture:**
-- Level sets are like contour lines on a topographic map
-- The gradient points perpendicular to these contours
-- It points "uphill" in the direction that crosses contours most rapidly
+**Geometric picture:** Level sets are like contour lines on a topographic map. The gradient points perpendicular to these contours, pointing "uphill" in the direction that crosses contours most rapidly.
 
 ### Example: Quadratic Functions and Ellipsoids
 
@@ -248,7 +279,7 @@ At any point $\mathbf{x}$ on an ellipsoid, the gradient $A\mathbf{x}$ points per
 
 This example shows how the gradient encodes both the geometry of the level sets and the local rate of change.
 
-## Part 3: The Jacobian—Vector-Valued Functions and Linear Maps
+## The Jacobian—Vector-Valued Functions and Linear Maps
 
 Now we return to the general case: **vector-valued functions** $f: \mathbb{R}^n \to \mathbb{R}^m$.
 
@@ -349,7 +380,7 @@ $$
 
 This theorem is fundamental in differential geometry, optimization, and numerical analysis.
 
-## Part 4: The Hessian—Second Derivatives and Curvature
+## The Hessian—Second Derivatives and Curvature
 
 The gradient tells us the **first-order** behavior of a function (its slope). To understand **curvature**—how the slope changes—we need second derivatives.
 
@@ -366,11 +397,7 @@ Hf(\mathbf{a}) = \begin{bmatrix}
 \end{bmatrix}
 $$
 
-**Key properties:**
-- The Hessian is an $n \times n$ matrix
-- Entry $(i,j)$ is $\frac{\partial^2 f}{\partial x_i \partial x_j}$
-- By Schwarz's theorem, if mixed partials are continuous, then $\frac{\partial^2 f}{\partial x_i \partial x_j} = \frac{\partial^2 f}{\partial x_j \partial x_i}$
-- Therefore, **the Hessian is symmetric**
+**Key properties:** The Hessian is an $n \times n$ symmetric matrix. Entry $(i,j)$ contains the mixed partial derivative $\frac{\partial^2 f}{\partial x_i \partial x_j}$. By Schwarz's theorem, when mixed partials are continuous, $\frac{\partial^2 f}{\partial x_i \partial x_j} = \frac{\partial^2 f}{\partial x_j \partial x_i}$, which is why the Hessian is symmetric.
 
 ### The Hessian is the Jacobian of the Gradient
 
@@ -400,9 +427,7 @@ $$
 
 The term $\mathbf{h}^T Hf(\mathbf{a}) \mathbf{h}$ is a **quadratic form**—it captures how $f$ curves in the direction $\mathbf{h}$.
 
-**For small $\mathbf{h}$:**
-- Linear term $\nabla f(\mathbf{a})^T \mathbf{h}$ dominates if $\nabla f(\mathbf{a}) \neq \mathbf{0}$
-- Quadratic term $\frac{1}{2}\mathbf{h}^T Hf(\mathbf{a}) \mathbf{h}$ becomes important when $\nabla f(\mathbf{a}) = \mathbf{0}$ (at critical points)
+**For small $\mathbf{h}$:** The linear term $\nabla f(\mathbf{a})^T \mathbf{h}$ dominates if $\nabla f(\mathbf{a}) \neq \mathbf{0}$, while the quadratic term $\frac{1}{2}\mathbf{h}^T Hf(\mathbf{a}) \mathbf{h}$ becomes important when $\nabla f(\mathbf{a}) = \mathbf{0}$ (at critical points).
 
 ### The Hessian and Critical Points
 
@@ -410,24 +435,7 @@ A point $\mathbf{a}$ is a **critical point** if $\nabla f(\mathbf{a}) = \mathbf{
 
 At a critical point, the linear approximation tells us nothing (the function is flat to first order). The Hessian determines whether the critical point is a local minimum, maximum, or saddle point.
 
-**Second Derivative Test:**
-
-If $\nabla f(\mathbf{a}) = \mathbf{0}$, then:
-
-1. **If $Hf(\mathbf{a})$ is positive definite** (all eigenvalues $> 0$): $\mathbf{a}$ is a **local minimum**
-   - The quadratic term $\mathbf{h}^T Hf(\mathbf{a}) \mathbf{h} > 0$ for all $\mathbf{h} \neq \mathbf{0}$
-   - The function curves upward in all directions
-
-2. **If $Hf(\mathbf{a})$ is negative definite** (all eigenvalues $< 0$): $\mathbf{a}$ is a **local maximum**
-   - The quadratic term $\mathbf{h}^T Hf(\mathbf{a}) \mathbf{h} < 0$ for all $\mathbf{h} \neq \mathbf{0}$
-   - The function curves downward in all directions
-
-3. **If $Hf(\mathbf{a})$ has both positive and negative eigenvalues**: $\mathbf{a}$ is a **saddle point**
-   - The function curves upward in some directions, downward in others
-   - Not a local extremum
-
-4. **If $Hf(\mathbf{a})$ is singular** (has zero eigenvalues): The test is **inconclusive**
-   - Higher-order terms are needed
+**Second Derivative Test:** If $\nabla f(\mathbf{a}) = \mathbf{0}$, the Hessian determines the nature of the critical point. When $Hf(\mathbf{a})$ is **positive definite** (all eigenvalues $> 0$), we have a **local minimum** where the quadratic term $\mathbf{h}^T Hf(\mathbf{a}) \mathbf{h} > 0$ for all $\mathbf{h} \neq \mathbf{0}$ and the function curves upward in all directions. When $Hf(\mathbf{a})$ is **negative definite** (all eigenvalues $< 0$), we have a **local maximum** where the quadratic term is negative and the function curves downward in all directions. If $Hf(\mathbf{a})$ has both positive and negative eigenvalues, then $\mathbf{a}$ is a **saddle point** where the function curves upward in some directions and downward in others—not a local extremum. Finally, if $Hf(\mathbf{a})$ is singular (has zero eigenvalues), the test is **inconclusive** and higher-order terms are needed.
 
 ### Geometric Interpretation: Principal Curvatures
 
@@ -447,33 +455,17 @@ $$
 
 where $h_i = \mathbf{h}^T \mathbf{v}_i$ are the components of $\mathbf{h}$ in the eigenbasis.
 
-**Geometric picture:**
-- Each eigenvector $\mathbf{v}_i$ is a **principal direction of curvature**
-- Each eigenvalue $\lambda_i$ is the **curvature** in that direction
-- Near a critical point, level sets are (approximately) ellipsoids aligned with the eigenvectors
-- The axes lengths are proportional to $1/\sqrt{|\lambda_i|}$
+**Geometric picture:** Each eigenvector $\mathbf{v}_i$ is a **principal direction of curvature**, and each eigenvalue $\lambda_i$ is the **curvature** in that direction. Near a critical point, level sets are approximately ellipsoids aligned with the eigenvectors, with axes lengths proportional to $1/\sqrt{|\lambda_i|}$.
 
-**Example:** For $f(\mathbf{x}) = \frac{1}{2}\mathbf{x}^T A \mathbf{x}$ (quadratic form), we have:
-- $\nabla f(\mathbf{x}) = A\mathbf{x}$
-- $Hf(\mathbf{x}) = A$ (constant!)
-- The eigenvalues of $A$ directly give the principal curvatures
-- The eigenvectors of $A$ give the principal axes of the level set ellipsoids
+**Example:** For a quadratic form $f(\mathbf{x}) = \frac{1}{2}\mathbf{x}^T A \mathbf{x}$, the gradient is $\nabla f(\mathbf{x}) = A\mathbf{x}$ and the Hessian is $Hf(\mathbf{x}) = A$ (constant everywhere!). The eigenvalues of $A$ directly give the principal curvatures, and the eigenvectors of $A$ give the principal axes of the level set ellipsoids.
 
 ### Condition Number and Optimization
 
 The **condition number** of the Hessian, $\kappa(Hf(\mathbf{a})) = \frac{\lambda_{\max}}{\lambda_{\min}}$, measures the **eccentricity** of the local quadratic approximation.
 
-**Large condition number** ($\kappa \gg 1$):
-- Level sets are very elongated ellipsoids
-- Function is much more curved in some directions than others
-- Gradient descent converges slowly (zigzagging)
-- Problem is **ill-conditioned**
+A **large condition number** ($\kappa \gg 1$) indicates that level sets are very elongated ellipsoids where the function is much more curved in some directions than others. This causes gradient descent to converge slowly with a characteristic zigzagging pattern—the problem is **ill-conditioned**.
 
-**Small condition number** ($\kappa \approx 1$):
-- Level sets are nearly spherical
-- Curvature is similar in all directions
-- Gradient descent converges quickly
-- Problem is **well-conditioned**
+A **small condition number** ($\kappa \approx 1$) indicates that level sets are nearly spherical with similar curvature in all directions. Here gradient descent converges quickly—the problem is **well-conditioned**.
 
 This is why **preconditioning** (transforming to make the Hessian more spherical) is crucial in optimization.
 
@@ -511,7 +503,7 @@ $$
 
 For quadratic functions, Newton's method converges in one step. For general functions, it has **quadratic convergence** near a minimum (errors square at each iteration).
 
-## Part 5: Connecting the Concepts
+## Synthesis: Connecting the Concepts
 
 Let's synthesize these ideas and see how they fit together.
 
@@ -552,27 +544,7 @@ The concepts generalize naturally from scalar to vector functions:
 
 ### Computational Perspective
 
-These concepts are essential for computational methods:
-
-**Gradient-based optimization:**
-- Gradient descent, SGD, Adam, etc.
-- Requires computing $\nabla f$
-- First-order methods
-
-**Newton-type methods:**
-- Newton's method, quasi-Newton (BFGS), Gauss-Newton
-- Require computing (or approximating) $Hf$
-- Second-order methods, faster convergence
-
-**Automatic differentiation:**
-- Forward mode: computes Jacobian-vector products efficiently
-- Reverse mode (backpropagation): computes vector-Jacobian products efficiently
-- Essential for deep learning
-
-**Numerical optimization:**
-- Finite differences approximate derivatives numerically
-- Understanding the differential helps choose appropriate step sizes
-- Condition number of Hessian predicts convergence behavior
+These concepts are essential for computational methods. **Gradient-based optimization** methods like gradient descent, SGD, and Adam require computing $\nabla f$ and are classified as first-order methods. **Newton-type methods** including Newton's method, quasi-Newton (BFGS), and Gauss-Newton require computing or approximating $Hf$ and achieve faster convergence as second-order methods. **Automatic differentiation** enables efficient computation through forward mode (Jacobian-vector products) and reverse mode or backpropagation (vector-Jacobian products), which is essential for deep learning. **Numerical optimization** uses finite differences to approximate derivatives numerically, where understanding the differential helps choose appropriate step sizes and the condition number of the Hessian predicts convergence behavior.
 
 ### Geometric Perspective Summary
 
@@ -588,18 +560,9 @@ All these concepts have unified geometric interpretations:
 
 ## Conclusion
 
-The differential is not just "the derivative"—it's a **linear map** that approximates a function. This perspective unifies:
+The differential is not just "the derivative"—it's a **linear map** that approximates a function. This perspective unifies the **gradient** as a special case for scalar functions, the **Jacobian** as the matrix representation for vector functions, and the **Hessian** as the differential of the gradient capturing second-order curvature.
 
-- The **gradient** as a special case (scalar functions)
-- The **Jacobian** as the matrix representation (vector functions)
-- The **Hessian** as the differential of the gradient (second-order curvature)
-
-Understanding these concepts geometrically—as tangent spaces, directions of steepest ascent, and curvature operators—provides the right mental model for:
-
-- Optimization (gradient descent, Newton's method)
-- Machine learning (backpropagation, loss landscapes)
-- Differential geometry (manifolds, tangent bundles)
-- Numerical analysis (convergence rates, conditioning)
+Understanding these concepts geometrically—as tangent spaces, directions of steepest ascent, and curvature operators—provides the right mental model for optimization (gradient descent, Newton's method), machine learning (backpropagation, loss landscapes), differential geometry (manifolds, tangent bundles), and numerical analysis (convergence rates, conditioning).
 
 The key insight: **differentiation is linear approximation.** The differential replaces a complicated nonlinear function with a simple linear one that captures local behavior. The gradient, Jacobian, and Hessian are different manifestations of this fundamental idea, each encoding geometric information about how functions change.
 


### PR DESCRIPTION
Major improvements:
- Add deep dive section on point vs direction to introduce tangent space
  conceptually, explaining the fundamental distinction between positions
  and velocities/directions before diving into differentials
- Convert all bullet points to flowing prose for better readability
- Remove "Part N" numbering from section headers for cleaner structure
- Consolidate content into focused thematic sections
- Enhance clarity by making key concepts more narrative and less list-based

The new structure emphasizes the conceptual foundation (point vs direction)
upfront, then builds the differential, gradient, Jacobian, and Hessian
concepts with more natural prose flow throughout.